### PR TITLE
[MDS-42] Custom properties values are not showing in admin UI in production

### DIFF
--- a/apps/medusa-plugin-shopify/src/admin/lib/sdk.ts
+++ b/apps/medusa-plugin-shopify/src/admin/lib/sdk.ts
@@ -1,14 +1,11 @@
 import Medusa from '@medusajs/js-sdk';
 
 // Defaults to standard port for Medusa server
-let MEDUSA_BACKEND_URL = 'http://localhost:9000';
+const DEFAULT_MEDUSA_BACKEND_URL = 'http://localhost:9000';
 
-if (import.meta.env.MEDUSA_BACKEND_URL) {
-  MEDUSA_BACKEND_URL = import.meta.env.MEDUSA_BACKEND_URL;
-}
 
 export const sdk = new Medusa({
-  baseUrl: MEDUSA_BACKEND_URL,
+  baseUrl: __BACKEND_URL__ || DEFAULT_MEDUSA_BACKEND_URL,
   debug: import.meta.env.NODE_ENV === 'development',
   auth: {
     type: 'session',

--- a/apps/medusa-plugin-shopify/src/admin/vite-env.d.ts
+++ b/apps/medusa-plugin-shopify/src/admin/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+// Reference: https://docs.medusajs.com/learn/fundamentals/admin/environment-variables#environment-variables-in-plugins
+declare const __BACKEND_URL__: string
+declare const __BASE__: string
+declare const __STOREFRONT_URL__: string


### PR DESCRIPTION
**Cause:**
The `MEDUSA_BACKEND_URL` env variable defined in `apps/medusa` is not accessible in `apps/medusa-plugin-shopify`.  It can be seen that in prod, it is using the default value we set for the MEDUSA_BACKEND_URL env variable (localhost:9000) in `src/admin/lib/sdk.ts`:

<img width="823" height="142" alt="image" src="https://github.com/user-attachments/assets/0d8b9400-208a-4684-bdc7-f53ef6d1196c" />
<br />
<br />

**Fix:**
Use `__BACKEND_URL__` to access the URL of the Medusa backend. This is according to the ff [docs](https://docs.medusajs.com/learn/fundamentals/admin/environment-variables#environment-variables-in-plugins).