### PR TITLE
[MDS-43] Resolve Algolia Search functionality not working in storefront production

### DIFF
--- a/apps/medusa-storefront/.env.template
+++ b/apps/medusa-storefront/.env.template
@@ -1,5 +1,5 @@
 # Your Medusa backend, should be updated to where you are hosting your server. Remember to update CORS settings for your server. See – https://docs.medusajs.com/learn/configurations/medusa-config#httpstorecors
-MEDUSA_BACKEND_URL=http://localhost:9000
+NEXT_PUBLIC_MEDUSA_BACKEND_URL=http://localhost:9000
 
 # Your publishable key that can be attached to sales channels. See - https://docs.medusajs.com/resources/storefront-development/publishable-api-keys
 NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test

--- a/apps/medusa-storefront/src/lib/config.ts
+++ b/apps/medusa-storefront/src/lib/config.ts
@@ -6,14 +6,11 @@ import {
 import Medusa from '@medusajs/js-sdk';
 
 // Defaults to standard port for Medusa server
-let MEDUSA_BACKEND_URL = 'http://localhost:9000';
-
-if (process.env.MEDUSA_BACKEND_URL) {
-  MEDUSA_BACKEND_URL = process.env.MEDUSA_BACKEND_URL;
-}
+const DEFAULT_MEDUSA_BACKEND_URL = 'http://localhost:9000';
 
 export const sdk = new Medusa({
-  baseUrl: MEDUSA_BACKEND_URL,
+  baseUrl:
+    process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL || DEFAULT_MEDUSA_BACKEND_URL,
   debug: process.env.NODE_ENV === 'development',
   publishableKey: process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY,
 });

--- a/apps/medusa-storefront/src/middleware.ts
+++ b/apps/medusa-storefront/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { HttpTypes } from '@medusajs/types';
 
-const BACKEND_URL = process.env.MEDUSA_BACKEND_URL;
+const BACKEND_URL = process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL;
 const PUBLISHABLE_API_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY;
 const DEFAULT_REGION = process.env.NEXT_PUBLIC_DEFAULT_REGION || 'us';
 
@@ -16,7 +16,7 @@ async function getRegionMap(cacheId: string) {
 
   if (!BACKEND_URL) {
     throw new Error(
-      'Middleware.ts: Error fetching regions. Did you set up regions in your Medusa Admin and define a MEDUSA_BACKEND_URL environment variable? Note that the variable is no longer named NEXT_PUBLIC_MEDUSA_BACKEND_URL.'
+      'Middleware.ts: Error fetching regions. Did you set up regions in your Medusa Admin and define a NEXT_PUBLIC_MEDUSA_BACKEND_URL environment variable? Note that the variable is no longer named NEXT_PUBLIC_MEDUSA_BACKEND_URL.'
     );
   }
 
@@ -97,7 +97,7 @@ async function getCountryCode(
   } catch (error) {
     if (process.env.NODE_ENV === 'development') {
       console.error(
-        'Middleware.ts: Error getting the country code. Did you set up regions in your Medusa Admin and define a MEDUSA_BACKEND_URL environment variable? Note that the variable is no longer named NEXT_PUBLIC_MEDUSA_BACKEND_URL.'
+        'Middleware.ts: Error getting the country code. Did you set up regions in your Medusa Admin and define a NEXT_PUBLIC_MEDUSA_BACKEND_URL environment variable? Note that the variable is no longer named NEXT_PUBLIC_MEDUSA_BACKEND_URL.'
       );
     }
   }


### PR DESCRIPTION
**Cause:**
The `MEDUSA_BACKEND_URL` env variable  is not accessible in the client/browser. It can be seen that in prod, it is using the default value we set for the MEDUSA_BACKEND_URL env variable (localhost:9000) in `src/lib/config.ts`:
<img width="1041" height="128" alt="image" src="https://github.com/user-attachments/assets/e2ec2a58-5aa9-4d2e-92ee-814ca140b157" />

**Fix:**
Prepend `NEXT_PUBLIC_` to backend URL env variable in storefront so that it can be accessible in the client/browser. This is also present in their [docs](https://docs.medusajs.com/resources/js-sdk#setup-js-sdk) about setting up JS SDK in storefront. 
