### PR TITLE
[MDS-46] use VITE_MEDUSA_BACKEND_URL for the backend url in admin ui

### DIFF
--- a/apps/medusa/.env.template
+++ b/apps/medusa/.env.template
@@ -7,7 +7,8 @@ COOKIE_SECRET=supersecret
 DATABASE_URL=
 DB_NAME=medusa-v2
 POSTGRES_URL=
-MEDUSA_BACKEND_URL=http://localhost:9000
+MEDUSA_BACKEND_URL=http://localhost:9000 #Necessary for server-side Medusa config
+VITE_MEDUSA_BACKEND_URL=http://localhost:9000 #Necessary for Admin UI
 PORT=9000
 
 # Algolia

--- a/apps/medusa/src/admin/lib/sdk.ts
+++ b/apps/medusa/src/admin/lib/sdk.ts
@@ -1,14 +1,10 @@
 import Medusa from '@medusajs/js-sdk';
 
 // Defaults to standard port for Medusa server
-let MEDUSA_BACKEND_URL = 'http://localhost:9000';
-
-if (import.meta.env.MEDUSA_BACKEND_URL) {
-  MEDUSA_BACKEND_URL = import.meta.env.MEDUSA_BACKEND_URL;
-}
+const DEFAULT_MEDUSA_BACKEND_URL = 'http://localhost:9000';
 
 export const sdk = new Medusa({
-  baseUrl: MEDUSA_BACKEND_URL,
+  baseUrl: import.meta.env.VITE_MEDUSA_BACKEND_URL || DEFAULT_MEDUSA_BACKEND_URL,
   debug: import.meta.env.NODE_ENV === 'development',
   auth: {
     type: 'session',


### PR DESCRIPTION
**Cause:**
The `MEDUSA_BACKEND_URL` env variable is not accessible in Admin UI. It can be seen that in prod, it is using the default value we set for the MEDUSA_BACKEND_URL env variable (localhost:9000) in `src/admin/lib/sdk.ts`:
<img width="830" height="123" alt="image" src="https://github.com/user-attachments/assets/825d1844-10cf-4816-b7c3-74ffe60eefeb" /> <br /><br />


**Fix:**
To be able to access env variables in Admin UI, which is Vite-powered, we need to prepend `VITE_` in the env variable. So for MEDUSA_BACKEND_URL, we need to use VITE_MEDUSA_BACKEND_URL: https://docs.medusajs.com/learn/fundamentals/admin/environment-variables#how-to-set-environment-variables. 

We still need to keep the MEDUSA_BACKEND_URL env variable for server-side Medusa config