### PR TITLE
[MDS-50] FIX: Add type assertion for useQueryGraphStep return data

### DIFF
--- a/apps/medusa/src/workflows/loyalty/apply-loyalty-on-cart.ts
+++ b/apps/medusa/src/workflows/loyalty/apply-loyalty-on-cart.ts
@@ -137,7 +137,7 @@ export const applyLoyaltyOnCartWorkflow = createWorkflow(
       },
       (data) => {
         const promos = [
-          ...((data.carts[0].promotions
+          ...(((data.carts[0] as CartData).promotions
             ?.map((promo) => promo?.code)
             .filter(Boolean) || []) as string[]),
           data.promoToCreate.code,


### PR DESCRIPTION
Fixes an issue on build where the return type for `useQueryGraphStep` is not inferred.