### PR TITLE
[MDS-71] Remove generateStaticParams to prevent making API calls to BFF at build time

### DIFF
--- a/apps/medusa-storefront/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/apps/medusa-storefront/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -1,9 +1,7 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
-import { getCategoryByHandle, listCategories } from '@lib/data/categories';
-import { listRegions } from '@lib/data/regions';
-import { StoreRegion } from '@medusajs/types';
+import { getCategoryByHandle } from '@lib/data/categories';
 import CategoryTemplate from '@modules/categories/templates';
 import { SortOptions } from '@modules/store/components/refinement-list/sort-products';
 
@@ -14,33 +12,6 @@ type Props = {
     page?: string;
   }>;
 };
-
-export async function generateStaticParams() {
-  const product_categories = await listCategories();
-
-  if (!product_categories) {
-    return [];
-  }
-
-  const countryCodes = await listRegions().then((regions: StoreRegion[]) =>
-    regions?.map((r) => r.countries?.map((c) => c.iso_2)).flat()
-  );
-
-  const categoryHandles = product_categories.map(
-    (category: any) => category.handle
-  );
-
-  const staticParams = countryCodes
-    ?.map((countryCode: string | undefined) =>
-      categoryHandles.map((handle: any) => ({
-        countryCode,
-        category: [handle],
-      }))
-    )
-    .flat();
-
-  return staticParams;
-}
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;

--- a/apps/medusa-storefront/src/app/[countryCode]/(main)/collections/[handle]/page.tsx
+++ b/apps/medusa-storefront/src/app/[countryCode]/(main)/collections/[handle]/page.tsx
@@ -1,9 +1,7 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
-import { getCollectionByHandle, listCollections } from '@lib/data/collections';
-import { listRegions } from '@lib/data/regions';
-import { StoreRegion } from '@medusajs/types';
+import { getCollectionByHandle } from '@lib/data/collections';
 import CollectionTemplate from '@modules/collections/templates';
 import { SortOptions } from '@modules/store/components/refinement-list/sort-products';
 
@@ -14,35 +12,6 @@ type Props = {
     sortBy?: SortOptions;
   }>;
 };
-
-export async function generateStaticParams() {
-  const { collections } = await listCollections();
-
-  if (!collections) {
-    return [];
-  }
-
-  const countryCodes = await listRegions().then(
-    (regions: StoreRegion[]) =>
-      regions
-        ?.map((r) => r.countries?.map((c) => c.iso_2))
-        .flat()
-        .filter(Boolean) as string[]
-  );
-
-  const collectionHandles = collections.map((collection) => collection.handle);
-
-  const staticParams = countryCodes
-    ?.map((countryCode: string) =>
-      collectionHandles.map((handle: string | undefined) => ({
-        countryCode,
-        handle,
-      }))
-    )
-    .flat();
-
-  return staticParams;
-}
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;


### PR DESCRIPTION
Issue: Build errors are found in Storefront deployment in Vercel due to API calls to BFF during build time
<img width="1437" height="302" alt="image" src="https://github.com/user-attachments/assets/2a6e7227-b3d7-451c-aab3-9bc443f2695f" />

Fix: This change is to prevent generating pages at build time making API calls to BFF server which could possibly be down (due to Render's free tier limitation) or too many requests are generated which Render's free tier can't also handle. This change will handle API calls per page at runtime or per request instead.